### PR TITLE
Parsing ansi color codes

### DIFF
--- a/cmd/core.go
+++ b/cmd/core.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/term"
 )
 
-const version = "0.3.3"
+const version = "0.3.4"
 
 func completionCommand() *cobra.Command {
 	return &cobra.Command{

--- a/src/ui/ui.go
+++ b/src/ui/ui.go
@@ -281,7 +281,7 @@ func (ui *UI) evaluateExpression() func() {
 			}
 		}
 		out, _ := program.Run(sb.String())
-		ui.OutputView.SetText(out)
+		ui.OutputView.SetText(tview.TranslateANSI(out))
 	}
 }
 

--- a/src/util/program.go
+++ b/src/util/program.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
+
+	"github.com/rivo/tview"
 )
 
 // Program being used
@@ -35,7 +37,7 @@ func shellout(command string, silent bool) (string, string, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	return stdout.String(), stderr.String(), err
+	return tview.TranslateANSI(stdout.String()), tview.TranslateANSI(stderr.String()), err
 }
 
 func Run(command string) (res string, err error) {

--- a/src/util/program.go
+++ b/src/util/program.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
-
-	"github.com/rivo/tview"
 )
 
 // Program being used
@@ -37,16 +35,16 @@ func shellout(command string, silent bool) (string, string, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	err := cmd.Run()
-	return tview.TranslateANSI(stdout.String()), tview.TranslateANSI(stderr.String()), err
+	return stdout.String(), stderr.String(), err
 }
 
 func Run(command string) (res string, err error) {
 
 	stdout, stderr, err := shellout(command, true)
 	if err != nil {
-		stderr = tview.TranslateANSI(stderr) + fmt.Sprint(tview.TranslateANSI(err.Error()))
+		stderr = stderr + fmt.Sprint(err)
 		return stderr, nil
 	}
 
-	return tview.TranslateANSI(stdout), nil
+	return stdout, nil
 }

--- a/src/util/program.go
+++ b/src/util/program.go
@@ -44,7 +44,7 @@ func Run(command string) (res string, err error) {
 
 	stdout, stderr, err := shellout(command, true)
 	if err != nil {
-		stderr = stderr + fmt.Sprint(err)
+		stderr = stderr + fmt.Sprint(tview.TranslateANSI(err.Error()))
 		return stderr, nil
 	}
 

--- a/src/util/program.go
+++ b/src/util/program.go
@@ -44,9 +44,9 @@ func Run(command string) (res string, err error) {
 
 	stdout, stderr, err := shellout(command, true)
 	if err != nil {
-		stderr = stderr + fmt.Sprint(tview.TranslateANSI(err.Error()))
+		stderr = tview.TranslateANSI(stderr) + fmt.Sprint(tview.TranslateANSI(err.Error()))
 		return stderr, nil
 	}
 
-	return stdout, nil
+	return tview.TranslateANSI(stdout), nil
 }


### PR DESCRIPTION
Using [tviews TranslateANSI](https://pkg.go.dev/github.com/rivo/tview#TranslateANSI) function to parse stdout and stderr for colorizing in `jq -C` and `grep --color="always`.  Not sure why `grep --color` on its own doesn't work


<img width="1728" alt="JQ colorized" src="https://github.com/user-attachments/assets/28cd3e80-6e70-4069-b1dd-378f805eb60b" />

